### PR TITLE
Fix path separator handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,7 +148,9 @@ function App() {
       contextAwareAiService.updateChatContext(files);
       
       // Generate project structure if we have multiple files with paths
-      const hasDirectoryStructure = files.some(f => f.path && f.path.includes('/'));
+      const hasDirectoryStructure = files.some(
+        f => f.path && (f.path.includes('/') || f.path.includes('\\'))
+      );
       if (hasDirectoryStructure) {
         const structure = contextAwareAiService.generateProjectStructureText();
         setProjectStructure(structure);

--- a/src/components/FileTracker.jsx
+++ b/src/components/FileTracker.jsx
@@ -18,9 +18,9 @@ const FileTracker = ({ files, onViewFile, onEditFile, isVisible, directoryStats 
     };
 
     files.forEach(file => {
-      if (file.path && file.path.includes('/')) {
-        // File has directory structure
-        const pathParts = file.path.split('/');
+      if (file.path && (file.path.includes('/') || file.path.includes('\\'))) {
+        // File has directory structure (support Windows paths)
+        const pathParts = file.path.split(/[/\\]/);
         const fileName = pathParts.pop();
         let currentLevel = tree;
         let currentPath = '';

--- a/src/services/contextAwareAiService.js
+++ b/src/services/contextAwareAiService.js
@@ -26,9 +26,9 @@ export class ContextAwareAIService {
     };
 
     files.forEach(file => {
-      if (file.path && file.path.includes('/')) {
-        // File has directory structure
-        const pathParts = file.path.split('/');
+      if (file.path && (file.path.includes('/') || file.path.includes('\\'))) {
+        // File has directory structure (support Windows paths)
+        const pathParts = file.path.split(/[/\\]/);
         const fileName = pathParts.pop();
         let currentLevel = structure;
 


### PR DESCRIPTION
## Summary
- support Windows-style paths when parsing directories

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_683fa6c9878c832b9923b9c007df83ae