### PR TITLE
Fix path parsing for Windows paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "test": "node --test"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.0",

--- a/src/components/FileTracker.jsx
+++ b/src/components/FileTracker.jsx
@@ -1,5 +1,6 @@
 // src/components/FileTracker.jsx (Enhanced with Directory Structure)
 import React, { useState, useMemo } from 'react';
+import { buildFileTree } from '../utils/fileTree.js';
 import { FileText, Eye, Edit3, Download, RefreshCw, Clock, AlertCircle, Plus, Folder, FolderOpen, ChevronRight, ChevronDown } from 'lucide-react';
 
 const FileTracker = ({ files, onViewFile, onEditFile, isVisible, directoryStats }) => {
@@ -8,57 +9,7 @@ const FileTracker = ({ files, onViewFile, onEditFile, isVisible, directoryStats 
   const [viewMode, setViewMode] = useState('tree'); // 'tree' or 'list'
 
   // Build hierarchical structure for tree view
-  const fileTree = useMemo(() => {
-    const tree = {
-      name: 'Project',
-      type: 'directory',
-      children: {},
-      files: [],
-      path: ''
-    };
-
-    files.forEach(file => {
-      if (file.path && (file.path.includes('/') || file.path.includes('\\'))) {
-        // File has directory structure (support Windows paths)
-        const pathParts = file.path.split(/[/\\]/);
-        const fileName = pathParts.pop();
-        let currentLevel = tree;
-        let currentPath = '';
-
-        // Build directory tree
-        pathParts.forEach((dirName, index) => {
-          currentPath += (index === 0 ? '' : '/') + dirName;
-          
-          if (!currentLevel.children[dirName]) {
-            currentLevel.children[dirName] = {
-              name: dirName,
-              type: 'directory',
-              children: {},
-              files: [],
-              path: currentPath
-            };
-          }
-          currentLevel = currentLevel.children[dirName];
-        });
-
-        // Add file to final directory
-        currentLevel.files.push({
-          ...file,
-          displayName: fileName,
-          parentPath: currentPath
-        });
-      } else {
-        // Root level file
-        tree.files.push({
-          ...file,
-          displayName: file.name,
-          parentPath: ''
-        });
-      }
-    });
-
-    return tree;
-  }, [files]);
+  const fileTree = useMemo(() => buildFileTree(files), [files]);
 
   const formatFileSize = (bytes) => {
     if (bytes === 0) return '0 B';

--- a/src/services/contextAwareAiService.js
+++ b/src/services/contextAwareAiService.js
@@ -1,5 +1,6 @@
 // src/services/contextAwareAiService.js
 import { invoke } from '@tauri-apps/api/core';
+import path from 'path';
 
 export class ContextAwareAIService {
   constructor() {
@@ -27,8 +28,9 @@ export class ContextAwareAIService {
 
     files.forEach(file => {
       if (file.path && (file.path.includes('/') || file.path.includes('\\'))) {
-        // File has directory structure (support Windows paths)
-        const pathParts = file.path.split(/[/\\]/);
+        // Normalize path and split using OS separator
+        const normalized = path.normalize(file.path).replace(/\\+/g, path.sep);
+        const pathParts = normalized.split(path.sep);
         const fileName = pathParts.pop();
         let currentLevel = structure;
 

--- a/src/utils/fileTree.js
+++ b/src/utils/fileTree.js
@@ -1,0 +1,50 @@
+import path from 'path';
+
+export function buildFileTree(files) {
+  const tree = {
+    name: 'Project',
+    type: 'directory',
+    children: {},
+    files: [],
+    path: ''
+  };
+
+  files.forEach(file => {
+    if (file.path && (file.path.includes('/') || file.path.includes('\\'))) {
+      const normalized = path.normalize(file.path).replace(/\\+/g, path.sep);
+      const pathParts = normalized.split(path.sep);
+      const fileName = pathParts.pop();
+      let currentLevel = tree;
+      let currentPath = '';
+
+      pathParts.forEach(dirName => {
+        currentPath = currentPath ? path.join(currentPath, dirName) : dirName;
+
+        if (!currentLevel.children[dirName]) {
+          currentLevel.children[dirName] = {
+            name: dirName,
+            type: 'directory',
+            children: {},
+            files: [],
+            path: currentPath
+          };
+        }
+        currentLevel = currentLevel.children[dirName];
+      });
+
+      currentLevel.files.push({
+        ...file,
+        displayName: fileName,
+        parentPath: currentPath
+      });
+    } else {
+      tree.files.push({
+        ...file,
+        displayName: file.name,
+        parentPath: ''
+      });
+    }
+  });
+
+  return tree;
+}

--- a/tests/pathHandling.test.js
+++ b/tests/pathHandling.test.js
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ContextAwareAIService } from '../src/services/contextAwareAiService.js';
+import { buildFileTree } from '../src/utils/fileTree.js';
+
+const sampleFiles = [
+  { id: 1, path: 'src\\utils\\helper.js', name: 'helper.js', extension: 'js', size: 10, content: '' },
+  { id: 2, path: 'src\\index.js', name: 'index.js', extension: 'js', size: 20, content: '' }
+];
+
+test('buildProjectStructure handles Windows paths', () => {
+  const svc = new ContextAwareAIService();
+  const structure = svc.buildProjectStructure(sampleFiles);
+  assert.ok(structure.children.src, 'src directory exists');
+  assert.ok(structure.children.src.children.utils, 'utils directory exists');
+  assert.strictEqual(structure.children.src.children.utils.files[0].displayName, 'helper.js');
+  assert.strictEqual(structure.children.src.files[0].displayName, 'index.js');
+});
+
+test('buildFileTree handles Windows paths', () => {
+  const files = [
+    { id: 1, path: 'src\\utils\\helper.js', name: 'helper.js', extension: 'js', size: 10, content: '' },
+    { id: 2, path: 'README.md', name: 'README.md', extension: 'md', size: 5, content: '' }
+  ];
+  const tree = buildFileTree(files);
+  assert.ok(tree.children.src.children.utils);
+  assert.strictEqual(tree.children.src.children.utils.files[0].displayName, 'helper.js');
+  assert.strictEqual(tree.files[0].displayName, 'README.md');
+});


### PR DESCRIPTION
## Summary
- use Node's `path` module when building project structure
- factor out `buildFileTree` util and use it in FileTracker
- add Node test script and tests with Windows paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fad1dec08832bbda8d0c34d536b74