### PR TITLE
Add Jest test for UpdateService

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test:watch": "npm run test -- --watch"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.0",
@@ -27,6 +29,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "jest": "^30.0.0"
   }
 }

--- a/tests/updateService.test.js
+++ b/tests/updateService.test.js
@@ -1,0 +1,21 @@
+import { UpdateService } from '../src/services/updateService.js';
+
+describe('isNewerVersion', () => {
+  const service = new UpdateService();
+
+  test('1.1.0 is newer than 1.0.0', () => {
+    expect(service.isNewerVersion('1.1.0', '1.0.0')).toBe(true);
+  });
+
+  test('1.0.1 is newer than 1.0.0', () => {
+    expect(service.isNewerVersion('1.0.1', '1.0.0')).toBe(true);
+  });
+
+  test('1.0.0 is not newer than 1.1.0', () => {
+    expect(service.isNewerVersion('1.0.0', '1.1.0')).toBe(false);
+  });
+
+  test('same versions are not newer', () => {
+    expect(service.isNewerVersion('1.0.0', '1.0.0')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add basic Jest config
- add version comparison unit tests for UpdateService
- provide npm scripts for running the tests

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_683fad29e61c832bb69a7ffb6d88e260