### PR TITLE
Standardize Luau spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Powered by [Ollama](https://ollama.com) and your desktop's development environme
 
 - 🧠 **Chat with your AI code reviewer** using natural language
 - ⚡ Fully **offline** after initial setup (no cloud needed)
-- 🧪 Supports **HTML/CSS, JavaScript, Python, Java, Lua, LuaU**
+- 🧪 Supports **HTML/CSS, JavaScript, Python, Java, Lua, Luau**
 - 🔍 Static analysis + sandboxed execution
 - 📝 Auto-fixes bugs and explains why
 - 📂 Reads files directly from your **Desktop**

--- a/src/components/InfoModal.jsx
+++ b/src/components/InfoModal.jsx
@@ -53,7 +53,7 @@ const InfoModal = ({ isOpen, onClose }) => {
              <ul className="text-gray-300 text-sm space-y-1">
                <li>• Code reviews and quality assessments</li>
                <li>• Learning and educational purposes</li>
-               <li>• Roblox/LuaU script development</li>
+              <li>• Roblox/Luau script development</li>
                <li>• Quick prototyping and experimentation</li>
                <li>• Best practice guidance and mentorship</li>
                <li>• Bug fixing and performance optimization</li>

--- a/src/components/NewFileModal.jsx
+++ b/src/components/NewFileModal.jsx
@@ -81,7 +81,7 @@ end
 -- Example usage
 print(greet("World"))
 `,
-      luau: `-- Roblox LuaU Script
+      luau: `-- Roblox Luau Script
 local Players = game:GetService("Players")
 local player = Players.LocalPlayer
 
@@ -222,7 +222,7 @@ int main() {
     python: { name: 'Python', ext: 'py', icon: '🐍' },
     javascript: { name: 'JavaScript', ext: 'js', icon: '🟨' },
     typescript: { name: 'TypeScript', ext: 'ts', icon: '🔷' },
-    lua: { name: 'Lua/LuaU', ext: 'lua', icon: '🌙' },
+    lua: { name: 'Lua/Luau', ext: 'lua', icon: '🌙' },
     java: { name: 'Java', ext: 'java', icon: '☕' },
     cpp: { name: 'C++', ext: 'cpp', icon: '⚙️' },
     html: { name: 'HTML', ext: 'html', icon: '🌐' },
@@ -318,7 +318,7 @@ int main() {
             </div>
             <div>
               <h2 className="text-xl font-bold text-white">Create New File</h2>
-              <p className="text-sm text-gray-400">Perfect for LuaU, Roblox scripts, or any code</p>
+              <p className="text-sm text-gray-400">Perfect for Luau, Roblox scripts, or any code</p>
             </div>
           </div>
           <button


### PR DESCRIPTION
## Summary
- use the "Luau" spelling everywhere
- update README and UI text
- keep the language mapping consistent

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_683fad0fa980832ba4ac0ec433e89e2b