### PR TITLE
Fix package.json syntax and update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "test": "node --test"
-    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test": "node --test",
     "test:watch": "npm run test -- --watch"
   },
   "dependencies": {

--- a/tests/updateService.test.js
+++ b/tests/updateService.test.js
@@ -1,21 +1,23 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
 import { UpdateService } from '../src/services/updateService.js';
 
 describe('isNewerVersion', () => {
   const service = new UpdateService();
 
   test('1.1.0 is newer than 1.0.0', () => {
-    expect(service.isNewerVersion('1.1.0', '1.0.0')).toBe(true);
+    assert.strictEqual(service.isNewerVersion('1.1.0', '1.0.0'), true);
   });
 
   test('1.0.1 is newer than 1.0.0', () => {
-    expect(service.isNewerVersion('1.0.1', '1.0.0')).toBe(true);
+    assert.strictEqual(service.isNewerVersion('1.0.1', '1.0.0'), true);
   });
 
   test('1.0.0 is not newer than 1.1.0', () => {
-    expect(service.isNewerVersion('1.0.0', '1.1.0')).toBe(false);
+    assert.strictEqual(service.isNewerVersion('1.0.0', '1.1.0'), false);
   });
 
   test('same versions are not newer', () => {
-    expect(service.isNewerVersion('1.0.0', '1.0.0')).toBe(false);
+    assert.strictEqual(service.isNewerVersion('1.0.0', '1.0.0'), false);
   });
 });


### PR DESCRIPTION
## Summary
- fix malformed `package.json`
- convert `updateService` tests to use `node:test`
- use Node's builtin test runner in `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb1692144832bb79220b95fd276ab