### PR TITLE
Add integrated offline chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ Powered by [Ollama](https://ollama.com) and your desktop's development environme
 ### 🔧 Install
 
 coming soon.
+
+### 🧠 Built-in AI Assistant
+
+PatchPilot ships with an integrated AI assistant powered by your locally
+installed Ollama model. Once a model is pulled, simply launch the desktop app
+and start asking questions or drop your code files for analysis – no cloud
+services required.
+
+A separate command‑line version is planned for a future paid release.

--- a/backend/chatbot.py
+++ b/backend/chatbot.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Simple CLI assistant for PatchPilot.
+
+This script uses a local Ollama model to answer questions and provide
+coding assistance. It does not rely on any external API and therefore
+works completely offline once a model has been downloaded.
+
+Set ``OLLAMA_MODEL`` to choose a different model
+(default: ``codellama:7b-instruct``).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def run_ollama(prompt: str, model: str = "codellama:7b-instruct") -> str:
+    """Run a prompt through the local Ollama model."""
+    result = subprocess.run(
+        ["ollama", "run", model, prompt], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip())
+    return result.stdout.strip()
+
+
+def ask(question: str) -> str:
+    """Handle a user question using the local Ollama model."""
+    model = os.getenv("OLLAMA_MODEL", "codellama:7b-instruct")
+    if not shutil.which("ollama"):
+        raise RuntimeError("Ollama is not installed or not in PATH")
+    return run_ollama(question, model)
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        prompt = " ".join(sys.argv[1:])
+    else:
+        prompt = sys.stdin.read()
+    if not prompt.strip():
+        print("Please provide a question or prompt.", file=sys.stderr)
+        sys.exit(1)
+    try:
+        answer = ask(prompt)
+        print(answer)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/services/chatbotService.js
+++ b/src/services/chatbotService.js
@@ -1,0 +1,15 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export class ChatbotService {
+  async ask(question) {
+    try {
+      const response = await invoke('ask_question', { question });
+      return { success: true, response };
+    } catch (error) {
+      console.error('Chatbot failed:', error);
+      return { success: false, error: error.message };
+    }
+  }
+}
+
+export const chatbotService = new ChatbotService();


### PR DESCRIPTION
## Summary
- add a `ask_question` command that runs the local `chatbot.py`
- expose chatbot service to the React UI
- call the chatbot when the user asks a general question
- update README to mention built-in assistant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fb508d460832bb83c99bebaeacabc