### PR TITLE
Fix duplicate handler causing build error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -374,24 +374,6 @@ function App() {
     ));
   }, [currentChatId]);
 
-  const handleRemoveFile = useCallback((fileId) => {
-    setChatFiles(prev => {
-      const updated = prev.filter(f => f.id !== fileId);
-      contextAwareAiService.updateChatContext(updated);
-      return updated;
-    });
-
-    const removed = chatFiles.find(f => f.id === fileId);
-    if (removed) {
-      handleAddMessage({
-        id: Date.now(),
-        type: 'ai',
-        content: `🗑️ Removed file: ${removed.name}`,
-        timestamp: new Date()
-      });
-    }
-  }, [chatFiles, handleAddMessage]);
-
   const handleChatRename = useCallback((chatId, code, filename, userMessage = '') => {
     const newName = generateSmartChatName(code, filename, userMessage, chatFiles);
     setChats(prev => prev.map(chat => 


### PR DESCRIPTION
## Summary
- remove the second `handleRemoveFile` callback in `App.jsx` to avoid redeclaration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68409043eddc832ba8d9c5ab5d61abe0