### PR TITLE
Fix React initialization order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -344,6 +344,18 @@ function App() {
     setEditorOpen(true);
   }, []);
 
+  const handleAddMessage = useCallback((message) => {
+    setChats(prev => prev.map(chat =>
+      chat.id === currentChatId
+        ? {
+            ...chat,
+            messages: [...chat.messages, message],
+            lastModified: Date.now()
+          }
+        : chat
+    ));
+  }, [currentChatId]);
+
   const handleRemoveFile = useCallback((fileId) => {
     setChatFiles(prev => {
       const updated = prev.filter(f => f.id !== fileId);
@@ -361,18 +373,6 @@ function App() {
       });
     }
   }, [chatFiles, handleAddMessage]);
-
-  const handleAddMessage = useCallback((message) => {
-    setChats(prev => prev.map(chat =>
-      chat.id === currentChatId
-        ? {
-            ...chat,
-            messages: [...chat.messages, message],
-            lastModified: Date.now()
-          }
-        : chat
-    ));
-  }, [currentChatId]);
 
   const handleChatRename = useCallback((chatId, code, filename, userMessage = '') => {
     const newName = generateSmartChatName(code, filename, userMessage, chatFiles);


### PR DESCRIPTION
## Summary
- avoid referencing `handleAddMessage` before its initialization by moving its definition above `handleRemoveFile`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684091a78cf0832bbc436860a99db5e7